### PR TITLE
Setup and configure ESLint and Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # qa-trainee-project-techstack
+
 Training project for QA Automation using Playwright and Typescript

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,33 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
+import prettierPlugin from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
+
+export default defineConfig([
+  {
+    files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
+    plugins: {
+      js,
+      prettier: prettierPlugin
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node
+      }
+    },
+    rules: {
+      'prettier/prettier': 'error'
+    }
+  },
+  js.configs.recommended,
+  tseslint.configs.recommended,
+  prettierConfig
+]);

--- a/example.ts
+++ b/example.ts
@@ -1,0 +1,2 @@
+const test = 'hello';
+console.log(test);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Training project for QA Automation using Playwright and Typescript",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint . --ext .js,.ts,.mjs",
+    "lint:fix": "eslint . --ext .js,.ts,.mjs --fix",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write ."
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
In this PR we installed and configured ESLint and Prettier:
- installed ESLint and Prettier using the command "npm install --save-dev eslint prettier";
- initialized ESLint: "npx eslint --init";
- installed ESLint plugins for Prettier: "npm install --save-dev eslint-config-prettier eslint-plugin-prettier";
- created and configured Prettier config file ".prettierrc.json";
- updated eslint.config.mjs file;
- added scripts to package.json file;
- added test file to verify correctness of ESLint and Prettier working together;