### PR TITLE
Config: enable parallel execution and set 3 workers on CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Tests and Upload Report
+name: Playwright Tests
 on:
   push:
     branches: [main, master]
@@ -9,8 +9,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -19,7 +21,8 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npx playwright test
-      - uses: actions/upload-artifact@v4
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main, master]
 jobs:
-  test:
+  run-ui-tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Run Playwright Tests and Upload Report
 on:
   push:
     branches: [main, master]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,13 +15,13 @@ export default defineConfig({
   testDir: './tests',
   timeout: 40_000, // Changed the default timeout value from 30_000 ms to 40_000 ms (maximum execution time of one test)
   /* Run tests in files in parallel */
-  fullyParallel: false,
+  fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 3 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
In this PR:
1. Set "fullyParallel: true" to allow parallel execution of tests within specs.
2. Set "workers: process.env.CI ? 3 : undefined" to run tests with 3 workers on CI for better performance.